### PR TITLE
Fix goakit error encoder

### DIFF
--- a/goakit/encode_decode_files.go
+++ b/goakit/encode_decode_files.go
@@ -137,7 +137,7 @@ const responseEncoderT = `{{ printf "%s returns a go-kit EncodeResponseFunc suit
 const errorEncoderT = `{{ printf "%s returns a go-kit EncodeResponseFunc suitable for encoding errors returned by the %s %s endpoint." .ErrorEncoder .ServiceName .Method.Name | comment }}
  func {{ .ErrorEncoder }}(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) kithttp.EncodeResponseFunc {
  	enc := server.{{ .ErrorEncoder }}(encoder)
-	return func(ctx context.Context, w http.ResponseWriter, v interface{}) error {
+	return func(ctx context.Context, v interface{}, w http.ResponseWriter) error {
 		enc(ctx, w, v.(error))
 		return nil
 	}


### PR DESCRIPTION
This updates the generated `encode_decode.go` files for go-kit to use the correct method signature for the errorEncoder that gets generated when using `Error()`, as per what go-kit expects in https://github.com/go-kit/kit/blob/618005da878c6f91827bd66bd1189403495df76f/transport/http/server.go#L132