### PR TITLE
Change error encoder to not return error

### DIFF
--- a/goakit/encode_decode_files.go
+++ b/goakit/encode_decode_files.go
@@ -137,9 +137,8 @@ const responseEncoderT = `{{ printf "%s returns a go-kit EncodeResponseFunc suit
 const errorEncoderT = `{{ printf "%s returns a go-kit EncodeResponseFunc suitable for encoding errors returned by the %s %s endpoint." .ErrorEncoder .ServiceName .Method.Name | comment }}
  func {{ .ErrorEncoder }}(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) kithttp.ErrorEncoder {
  	enc := server.{{ .ErrorEncoder }}(encoder)
-	return func(ctx context.Context, err error, w http.ResponseWriter) error {
+	return func(ctx context.Context, err error, w http.ResponseWriter) {
 		enc(ctx, w, err)
-		return nil
 	}
 }
 `

--- a/goakit/testdata/code.go
+++ b/goakit/testdata/code.go
@@ -61,9 +61,8 @@ var WithErrorMethodGoakitErrorEncoderCode = `// EncodeWithErrorMethodError retur
 // encoding errors returned by the WithErrorService WithErrorMethod endpoint.
 func EncodeWithErrorMethodError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) kithttp.ErrorEncoder {
 	enc := server.EncodeWithErrorMethodError(encoder)
-	return func(ctx context.Context, err error, w http.ResponseWriter) error {
+	return func(ctx context.Context, err error, w http.ResponseWriter) {
 		enc(ctx, w, err)
-		return nil
 	}
 }
 `
@@ -72,9 +71,8 @@ var Endpoint1GoakitErrorEncoderCode = `// EncodeEndpoint1Error returns a go-kit 
 // encoding errors returned by the MultiEndpointService Endpoint1 endpoint.
 func EncodeEndpoint1Error(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) kithttp.ErrorEncoder {
 	enc := server.EncodeEndpoint1Error(encoder)
-	return func(ctx context.Context, err error, w http.ResponseWriter) error {
+	return func(ctx context.Context, err error, w http.ResponseWriter) {
 		enc(ctx, w, err)
-		return nil
 	}
 }
 `
@@ -83,9 +81,8 @@ var Endpoint2GoakitErrorEncoderCode = `// EncodeEndpoint2Error returns a go-kit 
 // encoding errors returned by the MultiEndpointService Endpoint2 endpoint.
 func EncodeEndpoint2Error(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) kithttp.ErrorEncoder {
 	enc := server.EncodeEndpoint2Error(encoder)
-	return func(ctx context.Context, err error, w http.ResponseWriter) error {
+	return func(ctx context.Context, err error, w http.ResponseWriter) {
 		enc(ctx, w, err)
-		return nil
 	}
 }
 `


### PR DESCRIPTION
The resulting code with #26 doesn't compile because the signature of the error function should _not_ be returning an error.