### PR TITLE
Run goakitify after all plugins

### DIFF
--- a/cors/examples/calc/gen/http/calc/server/server.go
+++ b/cors/examples/calc/gen/http/calc/server/server.go
@@ -25,6 +25,12 @@ type Server struct {
 	CORS   http.Handler
 }
 
+// ErrorNamer is an interface implemented by generated error structs that
+// exposes the name of the error as defined in the design.
+type ErrorNamer interface {
+	ErrorName() string
+}
+
 // MountPoint holds information about the mounted endpoints.
 type MountPoint struct {
 	// Method is the name of the service method served by the mounted HTTP handler.
@@ -110,8 +116,8 @@ func NewAddHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/goakit/examples/calc/gen/http/calc/server/server.go
+++ b/goakit/examples/calc/gen/http/calc/server/server.go
@@ -23,6 +23,12 @@ type Server struct {
 	Add    http.Handler
 }
 
+// ErrorNamer is an interface implemented by generated error structs that
+// exposes the name of the error as defined in the design.
+type ErrorNamer interface {
+	ErrorName() string
+}
+
 // MountPoint holds information about the mounted endpoints.
 type MountPoint struct {
 	// Method is the name of the service method served by the mounted HTTP handler.
@@ -104,8 +110,8 @@ func NewAddHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/goakit/examples/fetcher/archiver/archiver.go
+++ b/goakit/examples/fetcher/archiver/archiver.go
@@ -3,9 +3,7 @@ package archiver
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"sync"
-	"time"
 
 	"github.com/go-kit/kit/log"
 	archiversvc "goa.design/plugins/goakit/examples/fetcher/archiver/gen/archiver"
@@ -37,11 +35,7 @@ func (s *archiversvcsvc) Archive(ctx context.Context, p *archiversvc.ArchivePayl
 func (s *archiversvcsvc) Read(ctx context.Context, p *archiversvc.ReadPayload) (*archiversvc.ArchiveMedia, error) {
 	doc := s.db.Read(p.ID)
 	if doc == nil {
-		return nil, &archiversvc.Error{
-			ID:      strconv.Itoa(int(time.Now().Unix())),
-			Name:    "bad_request",
-			Message: fmt.Sprintf("could not find document with ID %q", p.ID),
-		}
+		return nil, archiversvc.MakeBadRequest(fmt.Errorf("could not find document with ID %q", p.ID))
 	}
 	return archiveMedia(doc), nil
 }

--- a/goakit/examples/fetcher/archiver/archiver.go
+++ b/goakit/examples/fetcher/archiver/archiver.go
@@ -35,7 +35,7 @@ func (s *archiversvcsvc) Archive(ctx context.Context, p *archiversvc.ArchivePayl
 func (s *archiversvcsvc) Read(ctx context.Context, p *archiversvc.ReadPayload) (*archiversvc.ArchiveMedia, error) {
 	doc := s.db.Read(p.ID)
 	if doc == nil {
-		return nil, archiversvc.MakeBadRequest(fmt.Errorf("could not find document with ID %q", p.ID))
+		return nil, archiversvc.MakeNotFound(fmt.Errorf("could not find document with ID %q", p.ID))
 	}
 	return archiveMedia(doc), nil
 }

--- a/goakit/examples/fetcher/archiver/gen/archiver/client.go
+++ b/goakit/examples/fetcher/archiver/gen/archiver/client.go
@@ -38,10 +38,10 @@ func (c *Client) Archive(ctx context.Context, p *ArchivePayload) (res *ArchiveMe
 }
 
 // Read calls the "read" endpoint of the "archiver" service.
-// Read can return the following error types:
-//	- *Error
-//	- *Error
-//	- error: generic transport error.
+// Read may return the following errors:
+//	- "not_found" (type *goa.ServiceError)
+//	- "bad_request" (type *goa.ServiceError)
+//	- error: internal error
 func (c *Client) Read(ctx context.Context, p *ReadPayload) (res *ArchiveMedia, err error) {
 	var ires interface{}
 	ires, err = c.ReadEndpoint(ctx, p)

--- a/goakit/examples/fetcher/archiver/gen/archiver/service.go
+++ b/goakit/examples/fetcher/archiver/gen/archiver/service.go
@@ -55,38 +55,18 @@ type ReadPayload struct {
 	ID int
 }
 
-// Error response result type
-type Error struct {
-	// Name is the name of this class of errors.
-	Name string
-	// ID is a unique identifier for this particular occurrence of the problem.
-	ID string
-	// Message is a human-readable explanation specific to this occurrence of the
-	// problem.
-	Message string
-	// Is the error temporary?
-	Temporary bool
-	// Is the error a timeout?
-	Timeout bool
-}
-
-// Error returns "error".
-func (e *Error) Error() string {
-	return "error"
-}
-
-// MakeNotFound builds a Error from an error.
-func MakeNotFound(err error) *Error {
-	return &Error{
+// MakeNotFound builds a goa.ServiceError from an error.
+func MakeNotFound(err error) *goa.ServiceError {
+	return &goa.ServiceError{
 		Name:    "not_found",
 		ID:      goa.NewErrorID(),
 		Message: err.Error(),
 	}
 }
 
-// MakeBadRequest builds a Error from an error.
-func MakeBadRequest(err error) *Error {
-	return &Error{
+// MakeBadRequest builds a goa.ServiceError from an error.
+func MakeBadRequest(err error) *goa.ServiceError {
+	return &goa.ServiceError{
 		Name:    "bad_request",
 		ID:      goa.NewErrorID(),
 		Message: err.Error(),

--- a/goakit/examples/fetcher/archiver/gen/http/archiver/client/encode_decode.go
+++ b/goakit/examples/fetcher/archiver/gen/http/archiver/client/encode_decode.go
@@ -118,10 +118,10 @@ func (c *Client) BuildReadRequest(ctx context.Context, v interface{}) (*http.Req
 // DecodeReadResponse returns a decoder for responses returned by the archiver
 // read endpoint. restoreBody controls whether the response body should be
 // restored after having been read.
-// DecodeReadResponse may return the following error types:
-//	- *archiversvc.Error: http.StatusNotFound
-//	- *archiversvc.Error: http.StatusBadRequest
-//	- error: generic transport error.
+// DecodeReadResponse may return the following errors:
+//	- "not_found" (type *goa.ServiceError): http.StatusNotFound
+//	- "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//	- error: internal error
 func DecodeReadResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/goakit/examples/fetcher/archiver/gen/http/archiver/client/types.go
+++ b/goakit/examples/fetcher/archiver/gen/http/archiver/client/types.go
@@ -108,8 +108,8 @@ func NewReadArchiveMediaOK(body *ReadResponseBody) *archiversvc.ArchiveMedia {
 }
 
 // NewReadNotFound builds a archiver service read endpoint not_found error.
-func NewReadNotFound(body *ReadNotFoundResponseBody) *archiversvc.Error {
-	v := &archiversvc.Error{
+func NewReadNotFound(body *ReadNotFoundResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
 		Message:   *body.Message,
@@ -120,8 +120,8 @@ func NewReadNotFound(body *ReadNotFoundResponseBody) *archiversvc.Error {
 }
 
 // NewReadBadRequest builds a archiver service read endpoint bad_request error.
-func NewReadBadRequest(body *ReadBadRequestResponseBody) *archiversvc.Error {
-	v := &archiversvc.Error{
+func NewReadBadRequest(body *ReadBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
 		Message:   *body.Message,

--- a/goakit/examples/fetcher/archiver/gen/http/archiver/server/server.go
+++ b/goakit/examples/fetcher/archiver/gen/http/archiver/server/server.go
@@ -24,6 +24,12 @@ type Server struct {
 	Read    http.Handler
 }
 
+// ErrorNamer is an interface implemented by generated error structs that
+// exposes the name of the error as defined in the design.
+type ErrorNamer interface {
+	ErrorName() string
+}
+
 // MountPoint holds information about the mounted endpoints.
 type MountPoint struct {
 	// Method is the name of the service method served by the mounted HTTP handler.
@@ -109,8 +115,8 @@ func NewArchiveHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -159,8 +165,8 @@ func NewReadHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/goakit/examples/fetcher/archiver/gen/http/archiver/server/types.go
+++ b/goakit/examples/fetcher/archiver/gen/http/archiver/server/types.go
@@ -99,7 +99,7 @@ func NewReadResponseBody(res *archiversvc.ArchiveMedia) *ReadResponseBody {
 
 // NewReadNotFoundResponseBody builds the HTTP response body from the result of
 // the "read" endpoint of the "archiver" service.
-func NewReadNotFoundResponseBody(res *archiversvc.Error) *ReadNotFoundResponseBody {
+func NewReadNotFoundResponseBody(res *goa.ServiceError) *ReadNotFoundResponseBody {
 	body := &ReadNotFoundResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
@@ -112,7 +112,7 @@ func NewReadNotFoundResponseBody(res *archiversvc.Error) *ReadNotFoundResponseBo
 
 // NewReadBadRequestResponseBody builds the HTTP response body from the result
 // of the "read" endpoint of the "archiver" service.
-func NewReadBadRequestResponseBody(res *archiversvc.Error) *ReadBadRequestResponseBody {
+func NewReadBadRequestResponseBody(res *goa.ServiceError) *ReadBadRequestResponseBody {
 	body := &ReadBadRequestResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,

--- a/goakit/examples/fetcher/archiver/gen/http/health/server/server.go
+++ b/goakit/examples/fetcher/archiver/gen/http/health/server/server.go
@@ -23,6 +23,12 @@ type Server struct {
 	Show   http.Handler
 }
 
+// ErrorNamer is an interface implemented by generated error structs that
+// exposes the name of the error as defined in the design.
+type ErrorNamer interface {
+	ErrorName() string
+}
+
 // MountPoint holds information about the mounted endpoints.
 type MountPoint struct {
 	// Method is the name of the service method served by the mounted HTTP handler.
@@ -97,8 +103,8 @@ func NewShowHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/goakit/examples/fetcher/fetcher/gen/fetcher/client.go
+++ b/goakit/examples/fetcher/fetcher/gen/fetcher/client.go
@@ -26,10 +26,10 @@ func NewClient(fetch endpoint.Endpoint) *Client {
 }
 
 // Fetch calls the "fetch" endpoint of the "fetcher" service.
-// Fetch can return the following error types:
-//	- *Error
-//	- *Error
-//	- error: generic transport error.
+// Fetch may return the following errors:
+//	- "bad_request" (type *goa.ServiceError)
+//	- "internal_error" (type *goa.ServiceError)
+//	- error: internal error
 func (c *Client) Fetch(ctx context.Context, p *FetchPayload) (res *FetchMedia, err error) {
 	var ires interface{}
 	ires, err = c.FetchEndpoint(ctx, p)

--- a/goakit/examples/fetcher/fetcher/gen/fetcher/service.go
+++ b/goakit/examples/fetcher/fetcher/gen/fetcher/service.go
@@ -44,38 +44,18 @@ type FetchMedia struct {
 	ArchiveHref string
 }
 
-// Error response result type
-type Error struct {
-	// Name is the name of this class of errors.
-	Name string
-	// ID is a unique identifier for this particular occurrence of the problem.
-	ID string
-	// Message is a human-readable explanation specific to this occurrence of the
-	// problem.
-	Message string
-	// Is the error temporary?
-	Temporary bool
-	// Is the error a timeout?
-	Timeout bool
-}
-
-// Error returns "error".
-func (e *Error) Error() string {
-	return "error"
-}
-
-// MakeBadRequest builds a Error from an error.
-func MakeBadRequest(err error) *Error {
-	return &Error{
+// MakeBadRequest builds a goa.ServiceError from an error.
+func MakeBadRequest(err error) *goa.ServiceError {
+	return &goa.ServiceError{
 		Name:    "bad_request",
 		ID:      goa.NewErrorID(),
 		Message: err.Error(),
 	}
 }
 
-// MakeInternalError builds a Error from an error.
-func MakeInternalError(err error) *Error {
-	return &Error{
+// MakeInternalError builds a goa.ServiceError from an error.
+func MakeInternalError(err error) *goa.ServiceError {
+	return &goa.ServiceError{
 		Name:    "internal_error",
 		ID:      goa.NewErrorID(),
 		Message: err.Error(),

--- a/goakit/examples/fetcher/fetcher/gen/http/fetcher/client/encode_decode.go
+++ b/goakit/examples/fetcher/fetcher/gen/http/fetcher/client/encode_decode.go
@@ -47,10 +47,10 @@ func (c *Client) BuildFetchRequest(ctx context.Context, v interface{}) (*http.Re
 // DecodeFetchResponse returns a decoder for responses returned by the fetcher
 // fetch endpoint. restoreBody controls whether the response body should be
 // restored after having been read.
-// DecodeFetchResponse may return the following error types:
-//	- *fetchersvc.Error: http.StatusBadRequest
-//	- *fetchersvc.Error: http.StatusInternalServerError
-//	- error: generic transport error.
+// DecodeFetchResponse may return the following errors:
+//	- "bad_request" (type *goa.ServiceError): http.StatusBadRequest
+//	- "internal_error" (type *goa.ServiceError): http.StatusInternalServerError
+//	- error: internal error
 func DecodeFetchResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/goakit/examples/fetcher/fetcher/gen/http/fetcher/client/types.go
+++ b/goakit/examples/fetcher/fetcher/gen/http/fetcher/client/types.go
@@ -64,8 +64,8 @@ func NewFetchFetchMediaOK(body *FetchResponseBody) *fetchersvc.FetchMedia {
 }
 
 // NewFetchBadRequest builds a fetcher service fetch endpoint bad_request error.
-func NewFetchBadRequest(body *FetchBadRequestResponseBody) *fetchersvc.Error {
-	v := &fetchersvc.Error{
+func NewFetchBadRequest(body *FetchBadRequestResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
 		Message:   *body.Message,
@@ -77,8 +77,8 @@ func NewFetchBadRequest(body *FetchBadRequestResponseBody) *fetchersvc.Error {
 
 // NewFetchInternalError builds a fetcher service fetch endpoint internal_error
 // error.
-func NewFetchInternalError(body *FetchInternalErrorResponseBody) *fetchersvc.Error {
-	v := &fetchersvc.Error{
+func NewFetchInternalError(body *FetchInternalErrorResponseBody) *goa.ServiceError {
+	v := &goa.ServiceError{
 		Name:      *body.Name,
 		ID:        *body.ID,
 		Message:   *body.Message,

--- a/goakit/examples/fetcher/fetcher/gen/http/fetcher/server/server.go
+++ b/goakit/examples/fetcher/fetcher/gen/http/fetcher/server/server.go
@@ -23,6 +23,12 @@ type Server struct {
 	Fetch  http.Handler
 }
 
+// ErrorNamer is an interface implemented by generated error structs that
+// exposes the name of the error as defined in the design.
+type ErrorNamer interface {
+	ErrorName() string
+}
+
 // MountPoint holds information about the mounted endpoints.
 type MountPoint struct {
 	// Method is the name of the service method served by the mounted HTTP handler.
@@ -104,8 +110,8 @@ func NewFetchHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/goakit/examples/fetcher/fetcher/gen/http/fetcher/server/types.go
+++ b/goakit/examples/fetcher/fetcher/gen/http/fetcher/server/types.go
@@ -8,6 +8,7 @@
 package server
 
 import (
+	goa "goa.design/goa"
 	fetchersvc "goa.design/plugins/goakit/examples/fetcher/fetcher/gen/fetcher"
 )
 
@@ -64,7 +65,7 @@ func NewFetchResponseBody(res *fetchersvc.FetchMedia) *FetchResponseBody {
 
 // NewFetchBadRequestResponseBody builds the HTTP response body from the result
 // of the "fetch" endpoint of the "fetcher" service.
-func NewFetchBadRequestResponseBody(res *fetchersvc.Error) *FetchBadRequestResponseBody {
+func NewFetchBadRequestResponseBody(res *goa.ServiceError) *FetchBadRequestResponseBody {
 	body := &FetchBadRequestResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,
@@ -77,7 +78,7 @@ func NewFetchBadRequestResponseBody(res *fetchersvc.Error) *FetchBadRequestRespo
 
 // NewFetchInternalErrorResponseBody builds the HTTP response body from the
 // result of the "fetch" endpoint of the "fetcher" service.
-func NewFetchInternalErrorResponseBody(res *fetchersvc.Error) *FetchInternalErrorResponseBody {
+func NewFetchInternalErrorResponseBody(res *goa.ServiceError) *FetchInternalErrorResponseBody {
 	body := &FetchInternalErrorResponseBody{
 		Name:      res.Name,
 		ID:        res.ID,

--- a/goakit/examples/fetcher/fetcher/gen/http/health/server/server.go
+++ b/goakit/examples/fetcher/fetcher/gen/http/health/server/server.go
@@ -23,6 +23,12 @@ type Server struct {
 	Show   http.Handler
 }
 
+// ErrorNamer is an interface implemented by generated error structs that
+// exposes the name of the error as defined in the design.
+type ErrorNamer interface {
+	ErrorName() string
+}
+
 // MountPoint holds information about the mounted endpoints.
 type MountPoint struct {
 	// Method is the name of the service method served by the mounted HTTP handler.
@@ -97,8 +103,8 @@ func NewShowHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/goakit/generate.go
+++ b/goakit/generate.go
@@ -9,27 +9,30 @@ import (
 	httpdesign "goa.design/goa/http/design"
 )
 
-const pluginName = "goakit"
-
 // Register the plugin Generator functions.
 func init() {
-	codegen.RegisterPluginLast(pluginName, "gen", Generate)
-	codegen.RegisterPluginLast(pluginName, "example", Example)
+	codegen.RegisterPluginFirst("goakit", "gen", Generate)
+	codegen.RegisterPluginFirst("goakit", "example", Example)
+	codegen.RegisterPluginLast("goakit-goakitify", "gen", Goakitify)
 }
 
-// Generate modifies all the previously generated files by replacing all
-// instances of "goa.Endpoint" with "github.com/go-kit/kit/endpoint".Endpoint
-// and adding the corresponding import. Generate also generates go-kit
-// specific decoders and encoders.
+// Generate generates go-kit specific decoders and encoders.
 func Generate(genpkg string, roots []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
-	for _, f := range files {
-		goakitify(f)
-	}
 	for _, root := range roots {
 		if r, ok := root.(*httpdesign.RootExpr); ok {
 			files = append(files, EncodeDecodeFiles(genpkg, r)...)
 			files = append(files, MountFiles(r)...)
 		}
+	}
+	return files, nil
+}
+
+// Goakitify modifies all the previously generated files by replacing all
+// instances of "goa.Endpoint" with "github.com/go-kit/kit/endpoint".Endpoint
+// and adding the corresponding import.
+func Goakitify(enpkg string, roots []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
+	for _, f := range files {
+		goakitify(f)
 	}
 	return files, nil
 }

--- a/security/examples/calc/adder/gen/adder/client.go
+++ b/security/examples/calc/adder/gen/adder/client.go
@@ -26,10 +26,10 @@ func NewClient(add goa.Endpoint) *Client {
 }
 
 // Add calls the "add" endpoint of the "adder" service.
-// Add can return the following error types:
-//	- Unauthorized
-//	- InvalidScopes
-//	- error: generic transport error.
+// Add may return the following errors:
+//	- "unauthorized" (type Unauthorized)
+//	- "invalid-scopes" (type InvalidScopes)
+//	- error: internal error
 func (c *Client) Add(ctx context.Context, p *AddPayload) (res int, err error) {
 	var ires interface{}
 	ires, err = c.AddEndpoint(ctx, p)

--- a/security/examples/calc/adder/gen/adder/service.go
+++ b/security/examples/calc/adder/gen/adder/service.go
@@ -42,12 +42,22 @@ type Unauthorized string
 
 type InvalidScopes string
 
-// Error returns "unauthorized".
+// Error returns an error description.
 func (e Unauthorized) Error() string {
+	return ""
+}
+
+// ErrorName returns "unauthorized".
+func (e Unauthorized) ErrorName() string {
 	return "unauthorized"
 }
 
-// Error returns "invalid-scopes".
+// Error returns an error description.
 func (e InvalidScopes) Error() string {
+	return ""
+}
+
+// ErrorName returns "invalid-scopes".
+func (e InvalidScopes) ErrorName() string {
 	return "invalid-scopes"
 }

--- a/security/examples/calc/adder/gen/http/adder/client/encode_decode.go
+++ b/security/examples/calc/adder/gen/http/adder/client/encode_decode.go
@@ -64,10 +64,10 @@ func EncodeAddRequest(encoder func(*http.Request) goahttp.Encoder) func(*http.Re
 // DecodeAddResponse returns a decoder for responses returned by the adder add
 // endpoint. restoreBody controls whether the response body should be restored
 // after having been read.
-// DecodeAddResponse may return the following error types:
-//	- addersvc.InvalidScopes: http.StatusForbidden
-//	- addersvc.Unauthorized: http.StatusUnauthorized
-//	- error: generic transport error.
+// DecodeAddResponse may return the following errors:
+//	- "invalid-scopes" (type addersvc.InvalidScopes): http.StatusForbidden
+//	- "unauthorized" (type addersvc.Unauthorized): http.StatusUnauthorized
+//	- error: internal error
 func DecodeAddResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/security/examples/calc/adder/gen/http/adder/server/server.go
+++ b/security/examples/calc/adder/gen/http/adder/server/server.go
@@ -22,6 +22,12 @@ type Server struct {
 	Add    http.Handler
 }
 
+// ErrorNamer is an interface implemented by generated error structs that
+// exposes the name of the error as defined in the design.
+type ErrorNamer interface {
+	ErrorName() string
+}
+
 // MountPoint holds information about the mounted endpoints.
 type MountPoint struct {
 	// Method is the name of the service method served by the mounted HTTP handler.
@@ -103,8 +109,8 @@ func NewAddHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/security/examples/calc/calc/gen/calc/client.go
+++ b/security/examples/calc/calc/gen/calc/client.go
@@ -28,9 +28,9 @@ func NewClient(login, add goa.Endpoint) *Client {
 }
 
 // Login calls the "login" endpoint of the "calc" service.
-// Login can return the following error types:
-//	- Unauthorized
-//	- error: generic transport error.
+// Login may return the following errors:
+//	- "unauthorized" (type Unauthorized)
+//	- error: internal error
 func (c *Client) Login(ctx context.Context, p *LoginPayload) (res string, err error) {
 	var ires interface{}
 	ires, err = c.LoginEndpoint(ctx, p)

--- a/security/examples/calc/calc/gen/calc/service.go
+++ b/security/examples/calc/calc/gen/calc/service.go
@@ -50,7 +50,12 @@ type AddPayload struct {
 // Credentials are invalid
 type Unauthorized string
 
-// Error returns "unauthorized".
+// Error returns an error description.
 func (e Unauthorized) Error() string {
+	return "Credentials are invalid"
+}
+
+// ErrorName returns "unauthorized".
+func (e Unauthorized) ErrorName() string {
 	return "unauthorized"
 }

--- a/security/examples/calc/calc/gen/http/calc/client/encode_decode.go
+++ b/security/examples/calc/calc/gen/http/calc/client/encode_decode.go
@@ -37,9 +37,9 @@ func (c *Client) BuildLoginRequest(ctx context.Context, v interface{}) (*http.Re
 // DecodeLoginResponse returns a decoder for responses returned by the calc
 // login endpoint. restoreBody controls whether the response body should be
 // restored after having been read.
-// DecodeLoginResponse may return the following error types:
-//	- calcsvc.Unauthorized: http.StatusUnauthorized
-//	- error: generic transport error.
+// DecodeLoginResponse may return the following errors:
+//	- "unauthorized" (type calcsvc.Unauthorized): http.StatusUnauthorized
+//	- error: internal error
 func DecodeLoginResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/security/examples/calc/calc/gen/http/calc/server/encode_decode.go
+++ b/security/examples/calc/calc/gen/http/calc/server/encode_decode.go
@@ -44,8 +44,13 @@ func DecodeLoginRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.D
 func EncodeLoginError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		switch res := v.(type) {
-		case calcsvc.Unauthorized:
+		en, ok := v.(ErrorNamer)
+		if !ok {
+			return encodeError(ctx, w, v)
+		}
+		switch en.ErrorName() {
+		case "unauthorized":
+			res := v.(calcsvc.Unauthorized)
 			enc := encoder(ctx, w)
 			body := NewLoginUnauthorizedResponseBody(res)
 			w.WriteHeader(http.StatusUnauthorized)

--- a/security/examples/calc/calc/gen/http/calc/server/server.go
+++ b/security/examples/calc/calc/gen/http/calc/server/server.go
@@ -23,6 +23,12 @@ type Server struct {
 	Add    http.Handler
 }
 
+// ErrorNamer is an interface implemented by generated error structs that
+// exposes the name of the error as defined in the design.
+type ErrorNamer interface {
+	ErrorName() string
+}
+
 // MountPoint holds information about the mounted endpoints.
 type MountPoint struct {
 	// Method is the name of the service method served by the mounted HTTP handler.
@@ -108,8 +114,8 @@ func NewLoginHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -158,8 +164,8 @@ func NewAddHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/security/examples/multi_auth/gen/http/secured_service/client/encode_decode.go
+++ b/security/examples/multi_auth/gen/http/secured_service/client/encode_decode.go
@@ -38,9 +38,9 @@ func (c *Client) BuildSigninRequest(ctx context.Context, v interface{}) (*http.R
 // DecodeSigninResponse returns a decoder for responses returned by the
 // secured_service signin endpoint. restoreBody controls whether the response
 // body should be restored after having been read.
-// DecodeSigninResponse may return the following error types:
-//	- securedservice.Unauthorized: http.StatusUnauthorized
-//	- error: generic transport error.
+// DecodeSigninResponse may return the following errors:
+//	- "unauthorized" (type securedservice.Unauthorized): http.StatusUnauthorized
+//	- error: internal error
 func DecodeSigninResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -114,9 +114,9 @@ func EncodeSecureRequest(encoder func(*http.Request) goahttp.Encoder) func(*http
 // DecodeSecureResponse returns a decoder for responses returned by the
 // secured_service secure endpoint. restoreBody controls whether the response
 // body should be restored after having been read.
-// DecodeSecureResponse may return the following error types:
-//	- securedservice.Unauthorized: http.StatusUnauthorized
-//	- error: generic transport error.
+// DecodeSecureResponse may return the following errors:
+//	- "unauthorized" (type securedservice.Unauthorized): http.StatusUnauthorized
+//	- error: internal error
 func DecodeSecureResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -199,9 +199,9 @@ func EncodeDoublySecureRequest(encoder func(*http.Request) goahttp.Encoder) func
 // DecodeDoublySecureResponse returns a decoder for responses returned by the
 // secured_service doubly_secure endpoint. restoreBody controls whether the
 // response body should be restored after having been read.
-// DecodeDoublySecureResponse may return the following error types:
-//	- securedservice.Unauthorized: http.StatusUnauthorized
-//	- error: generic transport error.
+// DecodeDoublySecureResponse may return the following errors:
+//	- "unauthorized" (type securedservice.Unauthorized): http.StatusUnauthorized
+//	- error: internal error
 func DecodeDoublySecureResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {
@@ -288,9 +288,9 @@ func EncodeAlsoDoublySecureRequest(encoder func(*http.Request) goahttp.Encoder) 
 // DecodeAlsoDoublySecureResponse returns a decoder for responses returned by
 // the secured_service also_doubly_secure endpoint. restoreBody controls
 // whether the response body should be restored after having been read.
-// DecodeAlsoDoublySecureResponse may return the following error types:
-//	- securedservice.Unauthorized: http.StatusUnauthorized
-//	- error: generic transport error.
+// DecodeAlsoDoublySecureResponse may return the following errors:
+//	- "unauthorized" (type securedservice.Unauthorized): http.StatusUnauthorized
+//	- error: internal error
 func DecodeAlsoDoublySecureResponse(decoder func(*http.Response) goahttp.Decoder, restoreBody bool) func(*http.Response) (interface{}, error) {
 	return func(resp *http.Response) (interface{}, error) {
 		if restoreBody {

--- a/security/examples/multi_auth/gen/http/secured_service/server/encode_decode.go
+++ b/security/examples/multi_auth/gen/http/secured_service/server/encode_decode.go
@@ -41,8 +41,13 @@ func DecodeSigninRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.
 func EncodeSigninError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		switch res := v.(type) {
-		case securedservice.Unauthorized:
+		en, ok := v.(ErrorNamer)
+		if !ok {
+			return encodeError(ctx, w, v)
+		}
+		switch en.ErrorName() {
+		case "unauthorized":
+			res := v.(securedservice.Unauthorized)
 			enc := encoder(ctx, w)
 			body := NewSigninUnauthorizedResponseBody(res)
 			w.WriteHeader(http.StatusUnauthorized)
@@ -102,8 +107,13 @@ func DecodeSecureRequest(mux goahttp.Muxer, decoder func(*http.Request) goahttp.
 func EncodeSecureError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		switch res := v.(type) {
-		case securedservice.Unauthorized:
+		en, ok := v.(ErrorNamer)
+		if !ok {
+			return encodeError(ctx, w, v)
+		}
+		switch en.ErrorName() {
+		case "unauthorized":
+			res := v.(securedservice.Unauthorized)
 			enc := encoder(ctx, w)
 			body := NewSecureUnauthorizedResponseBody(res)
 			w.WriteHeader(http.StatusUnauthorized)
@@ -153,8 +163,13 @@ func DecodeDoublySecureRequest(mux goahttp.Muxer, decoder func(*http.Request) go
 func EncodeDoublySecureError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		switch res := v.(type) {
-		case securedservice.Unauthorized:
+		en, ok := v.(ErrorNamer)
+		if !ok {
+			return encodeError(ctx, w, v)
+		}
+		switch en.ErrorName() {
+		case "unauthorized":
+			res := v.(securedservice.Unauthorized)
 			enc := encoder(ctx, w)
 			body := NewDoublySecureUnauthorizedResponseBody(res)
 			w.WriteHeader(http.StatusUnauthorized)
@@ -209,8 +224,13 @@ func DecodeAlsoDoublySecureRequest(mux goahttp.Muxer, decoder func(*http.Request
 func EncodeAlsoDoublySecureError(encoder func(context.Context, http.ResponseWriter) goahttp.Encoder) func(context.Context, http.ResponseWriter, error) error {
 	encodeError := goahttp.ErrorEncoder(encoder)
 	return func(ctx context.Context, w http.ResponseWriter, v error) error {
-		switch res := v.(type) {
-		case securedservice.Unauthorized:
+		en, ok := v.(ErrorNamer)
+		if !ok {
+			return encodeError(ctx, w, v)
+		}
+		switch en.ErrorName() {
+		case "unauthorized":
+			res := v.(securedservice.Unauthorized)
 			enc := encoder(ctx, w)
 			body := NewAlsoDoublySecureUnauthorizedResponseBody(res)
 			w.WriteHeader(http.StatusUnauthorized)

--- a/security/examples/multi_auth/gen/http/secured_service/server/server.go
+++ b/security/examples/multi_auth/gen/http/secured_service/server/server.go
@@ -25,6 +25,12 @@ type Server struct {
 	AlsoDoublySecure http.Handler
 }
 
+// ErrorNamer is an interface implemented by generated error structs that
+// exposes the name of the error as defined in the design.
+type ErrorNamer interface {
+	ErrorName() string
+}
+
 // MountPoint holds information about the mounted endpoints.
 type MountPoint struct {
 	// Method is the name of the service method served by the mounted HTTP handler.
@@ -118,8 +124,8 @@ func NewSigninHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -168,8 +174,8 @@ func NewSecureHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -218,8 +224,8 @@ func NewDoublySecureHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)
@@ -269,8 +275,8 @@ func NewAlsoDoublySecureHandler(
 		if err != nil {
 			if err := encodeError(ctx, w, err); err != nil {
 				eh(ctx, w, err)
-				return
 			}
+			return
 		}
 		if err := encodeResponse(ctx, w, res); err != nil {
 			eh(ctx, w, err)

--- a/security/examples/multi_auth/gen/secured_service/service.go
+++ b/security/examples/multi_auth/gen/secured_service/service.go
@@ -79,7 +79,12 @@ type AlsoDoublySecurePayload struct {
 // Credentials are invalid
 type Unauthorized string
 
-// Error returns "unauthorized".
+// Error returns an error description.
 func (e Unauthorized) Error() string {
+	return "Credentials are invalid"
+}
+
+// ErrorName returns "unauthorized".
+func (e Unauthorized) ErrorName() string {
 	return "unauthorized"
 }


### PR DESCRIPTION
Fixes #36 - Goakit plugin should now produce code where the goakit decoders/encoders will use the secure decoders/encoders when used in tandem with security plugin.