### PR TITLE
Fix a path for getting golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,7 @@ PLUGINS=$(shell find . -mindepth 1 -maxdepth 1 -not -path "*/\.*" -type d)
 all: depend test-plugins test-aliaser
 
 depend:
-	@mkdir -p $(GOPATH)/src/golang.org/x
-	@git clone https://github.com/golang/lint.git $(GOPATH)/src/golang.org/x/lint | true
+	@go get -v golang.org/x/lint/golint
 
 gen:
 	@for p in $(PLUGINS) ; do \

--- a/plugins.mk
+++ b/plugins.mk
@@ -13,7 +13,7 @@ PLUGIN_DIR=goa.design/plugins
 
 DEPEND=\
   github.com/sergi/go-diff/diffmatchpatch \
-  github.com/golang/lint/golint \
+  golang.org/x/lint/golint \
   golang.org/x/tools/cmd/goimports \
 	goa.design/goa/...
 


### PR DESCRIPTION
Hello.

I changed golint package because "go get github.com/golang/lint/golint" is now fail.
"go get golang.org/x/lint/golint " is the right way now. (See [golint commit](https://github.com/golang/lint/commit/9a272034dedb2a3ed05231d5604ce17fb40f0e58) which introduce new behavior).

The PR also related with a PR [#1885](https://github.com/goadesign/goa/pull/1885)