### PR TITLE
Update of calls to RegisterPlugin and section renaming

### DIFF
--- a/cors/generate.go
+++ b/cors/generate.go
@@ -35,8 +35,8 @@ const pluginName = "cors"
 
 // Register the plugin Generator functions.
 func init() {
-	codegen.RegisterPlugin(pluginName, "gen", Generate)
-	codegen.RegisterPlugin(pluginName, "example", Example)
+	codegen.RegisterPlugin(pluginName, "gen", nil, Generate)
+	codegen.RegisterPlugin(pluginName, "example", nil, Example)
 }
 
 // Generate produces server code that handle preflight requests and updates
@@ -70,7 +70,7 @@ func Example(genpkg string, roots []eval.Root, files []*codegen.File) ([]*codege
 		}
 	}
 	for _, f := range files {
-		for _, s := range f.Section("service-main") {
+		for _, s := range f.Section("service-main-start") {
 			data := s.Data.(map[string]interface{})
 			svcs := data["Services"].([]*httpcodegen.ServiceData)
 			for _, sdata := range svcs {

--- a/goakit/generate.go
+++ b/goakit/generate.go
@@ -11,9 +11,9 @@ import (
 
 // Register the plugin Generator functions.
 func init() {
-	codegen.RegisterPluginFirst("goakit", "gen", Generate)
-	codegen.RegisterPluginFirst("goakit", "example", Example)
-	codegen.RegisterPluginLast("goakit-goakitify", "gen", Goakitify)
+	codegen.RegisterPluginFirst("goakit", "gen", nil, Generate)
+	codegen.RegisterPluginFirst("goakit", "example", nil, Example)
+	codegen.RegisterPluginLast("goakit-goakitify", "gen", nil, Goakitify)
 }
 
 // Generate generates go-kit specific decoders and encoders.


### PR DESCRIPTION
This PR updates the calls to the RegisterPlugin function in CORS and GOKIT plugins to take into account the new Prepare function parameter (goadesign/goa#1910).

It also renames the "service-main" section to "service-main-start" in the CORS plugin following to the split of the initial section into smaller ones (goadesign/goa#1912).