### PR TITLE
goakit: Mount kithttp.ServerErrorEncoder

### DIFF
--- a/goakit/generate.go
+++ b/goakit/generate.go
@@ -168,6 +168,7 @@ const gokitServerInitT = `
             func(context.Context, *http.Request) (request interface{}, err error) { return nil, nil },
           {{- end }}
           {{ .ServicePkgName}}kitsvr.{{ .ResponseEncoder }}(enc),
+          kithttp.ServerErrorEncoder({{ .ServicePkgName}}kitsvr.{{ .ErrorEncoder }}(enc)),
         )
       {{- end }}
       {{ .Service.VarName }}Server = {{ .Service.PkgName }}svr.New({{ .Service.VarName }}Endpoints, mux, dec, enc, eh{{ if needStream $.Services }}, upgrader, nil{{ end }}{{ range .Endpoints }}{{ if .MultipartRequestDecoder }}, {{ $.APIPkg }}.{{ .MultipartRequestDecoder.FuncName }}{{ end }}{{ end }})

--- a/goakit/generate.go
+++ b/goakit/generate.go
@@ -168,7 +168,9 @@ const gokitServerInitT = `
             func(context.Context, *http.Request) (request interface{}, err error) { return nil, nil },
           {{- end }}
           {{ .ServicePkgName}}kitsvr.{{ .ResponseEncoder }}(enc),
-          kithttp.ServerErrorEncoder({{ .ServicePkgName}}kitsvr.{{ .ErrorEncoder }}(enc)),
+          {{- if .Errors }}
+            kithttp.ServerErrorEncoder({{ .ServicePkgName}}kitsvr.{{ .ErrorEncoder }}(enc)),
+          {{- end }}
         )
       {{- end }}
       {{ .Service.VarName }}Server = {{ .Service.PkgName }}svr.New({{ .Service.VarName }}Endpoints, mux, dec, enc, eh{{ if needStream $.Services }}, upgrader, nil{{ end }}{{ range .Endpoints }}{{ if .MultipartRequestDecoder }}, {{ $.APIPkg }}.{{ .MultipartRequestDecoder.FuncName }}{{ end }}{{ end }})

--- a/goakit/generate_test.go
+++ b/goakit/generate_test.go
@@ -94,7 +94,7 @@ func TestGoakitifyExample(t *testing.T) {
 		"multi-services": {
 			DSL: testdata.MultiServiceDSL,
 			Code: map[string]string{
-				"service-main-server-init": testdata.MultiServicesServerInitCode,
+				"server-http-init": testdata.MultiServicesServerInitCode,
 			},
 		},
 	}

--- a/goakit/generate_test.go
+++ b/goakit/generate_test.go
@@ -97,6 +97,12 @@ func TestGoakitifyExample(t *testing.T) {
 				"server-http-init": testdata.MultiServicesServerInitCode,
 			},
 		},
+		"with-error": {
+			DSL: testdata.WithErrorDSL,
+			Code: map[string]string{
+				"server-http-init": testdata.WithErrorServerInitCode,
+			},
+		},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/goakit/testdata/code.go
+++ b/goakit/testdata/code.go
@@ -284,17 +284,19 @@ var MultiServicesServerInitCode = `func example() {
 		service2Server        *service2svr.Server
 	)
 	{
-		eh := ErrorHandler(logger)
+		eh := errorHandler(logger)
 		service1MethodHandler = kithttp.NewServer(
 			endpoint.Endpoint(service1Endpoints.Method),
 			func(context.Context, *http.Request) (request interface{}, err error) { return nil, nil },
 			service1kitsvr.EncodeMethodResponse(enc),
+			kithttp.ServerErrorEncoder(service1kitsvr.EncodeMethodError(enc)),
 		)
 		service1Server = service1svr.New(service1Endpoints, mux, dec, enc, eh)
 		service2MethodHandler = kithttp.NewServer(
 			endpoint.Endpoint(service2Endpoints.Method),
 			func(context.Context, *http.Request) (request interface{}, err error) { return nil, nil },
 			service2kitsvr.EncodeMethodResponse(enc),
+			kithttp.ServerErrorEncoder(service2kitsvr.EncodeMethodError(enc)),
 		)
 		service2Server = service2svr.New(service2Endpoints, mux, dec, enc, eh)
 	}

--- a/goakit/testdata/code.go
+++ b/goakit/testdata/code.go
@@ -289,14 +289,12 @@ var MultiServicesServerInitCode = `func example() {
 			endpoint.Endpoint(service1Endpoints.Method),
 			func(context.Context, *http.Request) (request interface{}, err error) { return nil, nil },
 			service1kitsvr.EncodeMethodResponse(enc),
-			kithttp.ServerErrorEncoder(service1kitsvr.EncodeMethodError(enc)),
 		)
 		service1Server = service1svr.New(service1Endpoints, mux, dec, enc, eh)
 		service2MethodHandler = kithttp.NewServer(
 			endpoint.Endpoint(service2Endpoints.Method),
 			func(context.Context, *http.Request) (request interface{}, err error) { return nil, nil },
 			service2kitsvr.EncodeMethodResponse(enc),
-			kithttp.ServerErrorEncoder(service2kitsvr.EncodeMethodError(enc)),
 		)
 		service2Server = service2svr.New(service2Endpoints, mux, dec, enc, eh)
 	}
@@ -304,5 +302,30 @@ var MultiServicesServerInitCode = `func example() {
 	// Configure the mux.
 	service1kitsvr.MountMethodHandler(mux, service1MethodHandler)
 	service2kitsvr.MountMethodHandler(mux, service2MethodHandler)
+}
+`
+
+var WithErrorServerInitCode = `func example() {
+	// Wrap the endpoints with the transport specific layers. The generated
+	// server packages contains code generated from the design which maps
+	// the service input and output data structures to HTTP requests and
+	// responses.
+	var (
+		withErrorServiceWithErrorMethodHandler *kithttp.Server
+		withErrorServiceServer                 *witherrorservicesvr.Server
+	)
+	{
+		eh := errorHandler(logger)
+		withErrorServiceWithErrorMethodHandler = kithttp.NewServer(
+			endpoint.Endpoint(withErrorServiceEndpoints.WithErrorMethod),
+			func(context.Context, *http.Request) (request interface{}, err error) { return nil, nil },
+			witherrorservicekitsvr.EncodeWithErrorMethodResponse(enc),
+			kithttp.ServerErrorEncoder(witherrorservicekitsvr.EncodeWithErrorMethodError(enc)),
+		)
+		withErrorServiceServer = witherrorservicesvr.New(withErrorServiceEndpoints, mux, dec, enc, eh)
+	}
+
+	// Configure the mux.
+	witherrorservicekitsvr.MountWithErrorMethodHandler(mux, withErrorServiceWithErrorMethodHandler)
 }
 `


### PR DESCRIPTION
If the behavior described in #81 is not as intended, this PR closes #81. go-kit allows user to use custom error encoder as describe in [here](https://godoc.org/github.com/go-kit/kit/transport/http#ServerErrorEncoder). This PR will use the custom error encoder in `kithttp.NewServer` when [goa DSL `Error(name string, args ...interface{})`](https://godoc.org/goa.design/goa/dsl#Error) is being used.

I've also added the test cases for this. Please let me know if I miss anything. Thank you for the reviews :heart: 