### PR TITLE
[WIP]Reverting cors generator

### DIFF
--- a/cors/generate.go
+++ b/cors/generate.go
@@ -143,9 +143,10 @@ func serverCORS(f *codegen.File) {
 	}
 	for _, s := range f.Section("server-init") {
 		s.Source = strings.Replace(s.Source,
-			`e.{{ .Method.VarName }}, mux, {{ if .MultipartRequestDecoder }}{{ .MultipartRequestDecoder.InitName }}(mux, {{ .MultipartRequestDecoder.VarName }}){{ else }}decoder{{ end }}, encoder, errhandler, formatter{{ if .ServerStream }}, upgrader, configurer.{{ .Method.VarName }}Fn{{ end }}`,
-			`{{ if ne .Method.VarName "CORS" }}e.{{ .Method.VarName }}, mux, {{ if .MultipartRequestDecoder }}{{ .MultipartRequestDecoder.InitName }}(mux, {{ .MultipartRequestDecoder.VarName }}){{ else }}decoder{{ end }}, encoder, errhandler, formatter{{ if .ServerStream }}, upgrader, configurer.{{ .Method.VarName }}Fn{{ end }}{{end}}`,
+			"e.{{ .Method.VarName }}, mux, {{ if .MultipartRequestDecoder }}{{ .MultipartRequestDecoder.InitName }}(mux, {{ .MultipartRequestDecoder.VarName }}){{ else }}dec{{ end }}, enc, eh",
+			`{{ if ne .Method.VarName "CORS" }}e.{{ .Method.VarName }}, mux, {{ if .MultipartRequestDecoder }}{{ .MultipartRequestDecoder.InitName }}(mux, {{ .MultipartRequestDecoder.VarName }}){{ else }}dec{{ end }}, enc, eh{{ end }}`,
 			-1)
+
 	}
 	for _, s := range f.Section("server-handler") {
 		s.Source = strings.Replace(s.Source, "h.(http.HandlerFunc)", svcData.OriginHandler+"(h).(http.HandlerFunc)", -1)

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.10.0
 	goa.design/goa/v3 v3.0.10
+	google.golang.org/appengine v1.4.0 // indirect
 )


### PR DESCRIPTION
**What changes does this PR bring?**
Reverts changes seen in release 3.0.10 where each server object was attempting to have a CORS handler as seen below
# github.com/flexera/optima_bill/front_service/gen/http/azure_mca_enterprise_bill_connects/server
front_service/gen/http/azure_mca_enterprise_bill_connects/server/server.go:76:25: too many arguments in call to NewCORSHandler
front_service/gen/http/azure_mca_enterprise_bill_connects/server/server.go:76:27: e.CORS undefined (type *azuremcaenterprisebillconnects.Endpoints has no field or method CORS)

**Are tests included? (if applicable)**

Unit tests are included, and local testing as seen below:

All unit tests pass for a goa v3 generated service with this change:
<img width="1440" alt="Screen Shot 2020-02-19 at 17 28 03" src="https://user-images.githubusercontent.com/23276481/74859060-3de95100-533e-11ea-8d17-5271ad12339e.png">

Code generation still works as intended:

<img width="1440" alt="Screen Shot 2020-02-19 at 17 28 57" src="https://user-images.githubusercontent.com/23276481/74859144-5c4f4c80-533e-11ea-881b-4397835b3c12.png">


**Types of review(s) required?**

Sanity check, code review, local testing 
