### PR TITLE
unique TypeName for payload/result

### DIFF
--- a/docs/generate.go
+++ b/docs/generate.go
@@ -193,7 +193,14 @@ func generateMethod(api *expr.APIExpr, meth *expr.MethodExpr) *methodData {
 	return m
 }
 
+var uniqDef = codegen.NewNameScope()
+
 func generatePayload(api *expr.APIExpr, att *expr.AttributeExpr, streaming bool) *payloadData {
+	// since the definitions section is global to the API, we need to ensure uniqueness of TypeName
+	if ut, ok := att.Type.(*expr.UserTypeExpr); ok {
+		ut.TypeName = uniqDef.Unique(ut.TypeName)
+	}
+
 	schema := openapi.AttributeTypeSchema(api, att)
 	return &payloadData{
 		Type:      schema,

--- a/docs/generate.go
+++ b/docs/generate.go
@@ -19,10 +19,13 @@ func init() {
 	codegen.RegisterPlugin("docs", "gen", nil, Generate)
 }
 
+var uniqDef *codegen.NameScope
+
 // Generate produces the documentation JSON file.
 func Generate(_ string, roots []eval.Root, files []*codegen.File) ([]*codegen.File, error) {
 	for _, root := range roots {
 		if r, ok := root.(*expr.RootExpr); ok {
+			uniqDef = codegen.NewNameScope()
 			files = append(files, docsFile(r))
 		}
 	}
@@ -193,12 +196,12 @@ func generateMethod(api *expr.APIExpr, meth *expr.MethodExpr) *methodData {
 	return m
 }
 
-var uniqDef = codegen.NewNameScope()
-
 func generatePayload(api *expr.APIExpr, att *expr.AttributeExpr, streaming bool) *payloadData {
 	// since the definitions section is global to the API, we need to ensure uniqueness of TypeName
 	if ut, ok := att.Type.(*expr.UserTypeExpr); ok {
-		ut.TypeName = uniqDef.Unique(ut.TypeName)
+		if ut != expr.Empty {
+			ut.TypeName = uniqDef.Unique(ut.TypeName)
+		}
 	}
 
 	schema := openapi.AttributeTypeSchema(api, att)


### PR DESCRIPTION
Since the definitions section in docs.json is global, we need to ensure uniqueness of TypeName for request payload and result payload.