### PR TITLE
v2: Add `Vary: Origin` header When use cors.Origin("*")

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.11.x
+- 1.13.x
 env:
   matrix:
 install:

--- a/cors/generate.go
+++ b/cors/generate.go
@@ -203,9 +203,7 @@ func {{ .OriginHandler }}(h http.Handler) http.Handler {
 		if cors.MatchOrigin(origin, {{ printf "%q" $policy.Origin }}) {
 		{{- end }}
       w.Header().Set("Access-Control-Allow-Origin", origin)
-			{{- if not (eq $policy.Origin "*") }}
 			w.Header().Set("Vary", "Origin")
-			{{- end }}
 			{{- if $policy.Exposed }}
 			w.Header().Set("Access-Control-Expose-Headers", "{{ join $policy.Exposed ", " }}")
 			{{- end }}


### PR DESCRIPTION
fix #95 