### PR TITLE
Set Access-Control-Allow-Credentials header only when the value is true

### DIFF
--- a/cors/examples/calc/gen/http/calc/server/server.go
+++ b/cors/examples/calc/gen/http/calc/server/server.go
@@ -170,7 +170,6 @@ func handleCalcOrigin(h http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin")
 			w.Header().Set("Access-Control-Expose-Headers", "X-Time, X-Api-Version")
 			w.Header().Set("Access-Control-Max-Age", "100")
-			w.Header().Set("Access-Control-Allow-Credentials", "false")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST")

--- a/cors/generate.go
+++ b/cors/generate.go
@@ -210,7 +210,9 @@ func {{ .OriginHandler }}(h http.Handler) http.Handler {
 			{{- if gt $policy.MaxAge 0 }}
 		w.Header().Set("Access-Control-Max-Age", "{{ $policy.MaxAge }}")
 			{{- end }}
+			{{- if eq $policy.Credentials true }}
 		w.Header().Set("Access-Control-Allow-Credentials", "{{ $policy.Credentials }}")
+			{{- end }}
 		if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 			// We are handling a preflight request
 				{{- if $policy.Methods }}

--- a/cors/testdata/code.go
+++ b/cors/testdata/code.go
@@ -14,7 +14,6 @@ func handleSimpleOriginOrigin(h http.Handler) http.Handler {
 		if cors.MatchOrigin(origin, "SimpleOrigin") {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
-			w.Header().Set("Access-Control-Allow-Credentials", "false")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 			}
@@ -42,7 +41,6 @@ func handleRegexpOriginOrigin(h http.Handler) http.Handler {
 		if cors.MatchOriginRegexp(origin, spec0) {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
-			w.Header().Set("Access-Control-Allow-Credentials", "false")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 			}
@@ -72,7 +70,6 @@ func handleMultiOriginOrigin(h http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin")
 			w.Header().Set("Access-Control-Expose-Headers", "X-Time, X-Api-Version")
 			w.Header().Set("Access-Control-Max-Age", "100")
-			w.Header().Set("Access-Control-Allow-Credentials", "false")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST")
@@ -114,7 +111,6 @@ func handleOriginFileServerOrigin(h http.Handler) http.Handler {
 		if cors.MatchOrigin(origin, "OriginFileServer") {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
-			w.Header().Set("Access-Control-Allow-Credentials", "false")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 			}
@@ -141,7 +137,6 @@ func handleOriginMultiEndpointOrigin(h http.Handler) http.Handler {
 		if cors.MatchOrigin(origin, "OriginMultiEndpoint") {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
-			w.Header().Set("Access-Control-Allow-Credentials", "false")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 			}
@@ -168,7 +163,6 @@ func handleFirstServiceOrigin(h http.Handler) http.Handler {
 		if cors.MatchOrigin(origin, "SimpleOrigin") {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
-			w.Header().Set("Access-Control-Allow-Credentials", "false")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 			}
@@ -194,7 +188,6 @@ func handleSecondServiceOrigin(h http.Handler) http.Handler {
 		if cors.MatchOrigin(origin, "SimpleOrigin") {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
-			w.Header().Set("Access-Control-Allow-Credentials", "false")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 			}

--- a/zerologger/generate.go
+++ b/zerologger/generate.go
@@ -146,7 +146,7 @@ func updateExampleFile(genpkg string, root *expr.RootExpr, f *fileToModify) {
 	}
 }
 
-const loggerT =`
+const loggerT = `
 // Logger is an adapted zerologger
 type Logger struct {
 	*zerolog.Logger


### PR DESCRIPTION
@raphael  Thank you for the great plugins.

Currently, `Access-Control-Allow-Credentials` header is set in both cases the value is `true` and `false`.
However, the [MDN Doc](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials#directives) says we should omit this header if credentials are unnecessary.

This PR omits the header if the value is `false`.