### PR TITLE
Fix import

### DIFF
--- a/cors/README.md
+++ b/cors/README.md
@@ -11,7 +11,7 @@ the `dsl` packages as follows:
 
 ```go
 import (
-  cors "goa.design/plugins/v3/cors/dsl"
+  _ "goa.design/plugins/v3/cors/dsl"
   . "goa.design/goa/v3/dsl"
 )
 ```


### PR DESCRIPTION
I am pretty sure that this doc is incorrect. It imports as `cors` even though the sentence below it says that it is using the blank identifier.