### PR TITLE
Add unicode/utf8 to types imports

### DIFF
--- a/types/generate.go
+++ b/types/generate.go
@@ -43,6 +43,7 @@ func typesFile(genpkg string, r *expr.RootExpr) *codegen.File {
 	header := codegen.Header("Data types", "types",
 		[]*codegen.ImportSpec{
 			codegen.GoaImport(""),
+			{Path: "unicode/utf8"},
 		},
 	)
 	sections := []*codegen.SectionTemplate{header}

--- a/types/testdata/alias.go_
+++ b/types/testdata/alias.go_
@@ -6,7 +6,10 @@
 
 package types
 
-import 	goa "goa.design/goa/v3/pkg"
+import (
+	goa "goa.design/goa/v3/pkg"
+	"unicode/utf8"
+)
 
 
 type Alias string

--- a/types/testdata/array.go_
+++ b/types/testdata/array.go_
@@ -6,7 +6,10 @@
 
 package types
 
-import 	goa "goa.design/goa/v3/pkg"
+import (
+	goa "goa.design/goa/v3/pkg"
+	"unicode/utf8"
+)
 
 
 type Array struct {

--- a/types/testdata/empty.go_
+++ b/types/testdata/empty.go_
@@ -6,7 +6,10 @@
 
 package types
 
-import 	goa "goa.design/goa/v3/pkg"
+import (
+	goa "goa.design/goa/v3/pkg"
+	"unicode/utf8"
+)
 
 
 

--- a/types/testdata/example.go_
+++ b/types/testdata/example.go_
@@ -6,7 +6,10 @@
 
 package types
 
-import 	goa "goa.design/goa/v3/pkg"
+import (
+	goa "goa.design/goa/v3/pkg"
+	"unicode/utf8"
+)
 
 // My type
 type MyType struct {

--- a/types/testdata/multiple.go_
+++ b/types/testdata/multiple.go_
@@ -6,7 +6,10 @@
 
 package types
 
-import 	goa "goa.design/goa/v3/pkg"
+import (
+	goa "goa.design/goa/v3/pkg"
+	"unicode/utf8"
+)
 
 
 type AType struct {

--- a/types/testdata/noval.go_
+++ b/types/testdata/noval.go_
@@ -6,7 +6,10 @@
 
 package types
 
-import 	goa "goa.design/goa/v3/pkg"
+import (
+	goa "goa.design/goa/v3/pkg"
+	"unicode/utf8"
+)
 
 
 type NoVal struct {

--- a/types/testdata/novalidation.go_
+++ b/types/testdata/novalidation.go_
@@ -6,7 +6,10 @@
 
 package types
 
-import 	goa "goa.design/goa/v3/pkg"
+import (
+	goa "goa.design/goa/v3/pkg"
+	"unicode/utf8"
+)
 
 type (
 	NoVal struct {

--- a/types/testdata/recArray.go_
+++ b/types/testdata/recArray.go_
@@ -6,7 +6,10 @@
 
 package types
 
-import 	goa "goa.design/goa/v3/pkg"
+import (
+	goa "goa.design/goa/v3/pkg"
+	"unicode/utf8"
+)
 
 
 type ArrayArray struct {

--- a/types/testdata/required.go_
+++ b/types/testdata/required.go_
@@ -6,7 +6,10 @@
 
 package types
 
-import 	goa "goa.design/goa/v3/pkg"
+import (
+	goa "goa.design/goa/v3/pkg"
+	"unicode/utf8"
+)
 
 
 type Require struct {

--- a/types/testdata/validation.go_
+++ b/types/testdata/validation.go_
@@ -6,7 +6,10 @@
 
 package types
 
-import 	goa "goa.design/goa/v3/pkg"
+import (
+	goa "goa.design/goa/v3/pkg"
+	"unicode/utf8"
+)
 
 
 type Validation struct {


### PR DESCRIPTION
When generating validation methods for types that include a `MinLength` and `MaxLength`, the `unicode/utf8` package is used to validate string lengths. This PR adds it to the list of imports so that the code is functional when generated.