### PR TITLE
CORS OPTIONS should always return 200

### DIFF
--- a/cors/generate.go
+++ b/cors/generate.go
@@ -235,7 +235,7 @@ func {{ .OriginHandler }}(h http.Handler) http.Handler {
 			w.Header().Set("Access-Control-Allow-Headers", "{{ join $policy.Headers ", " }}")
 				{{- end }}
 		}
-		h.ServeHTTP(w, r)
+		w.WriteHeader(http.StatusOK)
 		return
 	}
 	{{- end }}


### PR DESCRIPTION
A CORS OPTIONS request is better off always returning 200. For example, if the OPTIONS request is for a url that doesn't exist, then the current code will return a 404. That will result in the browser giving a network error on the actual request. Whereas if a 200 was returned, the browser will make the actual request and get an actual 404 result. Similar for a 401 that is derived from middleware, etc.

I did not test this change. Let me know if it makes sense and I can look at testing.