### PR TITLE
cors: always return 204 for a matched preflight

### DIFF
--- a/cors/examples/calc/gen/http/calc/server/server.go
+++ b/cors/examples/calc/gen/http/calc/server/server.go
@@ -157,10 +157,10 @@ func MountCORSHandler(mux goahttp.Muxer, h http.Handler) {
 	mux.Handle("OPTIONS", "/", h.ServeHTTP)
 }
 
-// NewCORSHandler creates a HTTP handler which returns a simple 200 response.
+// NewCORSHandler creates a HTTP handler which returns a simple 204 response.
 func NewCORSHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(204)
 	})
 }
 
@@ -183,6 +183,8 @@ func HandleCalcOrigin(h http.Handler) http.Handler {
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST")
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return
@@ -197,6 +199,8 @@ func HandleCalcOrigin(h http.Handler) http.Handler {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST")
 				w.Header().Set("Access-Control-Allow-Headers", "X-Shared-Secret")
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return

--- a/cors/generate.go
+++ b/cors/generate.go
@@ -166,10 +166,10 @@ func serverCORS(f *codegen.File) {
 }
 
 // Data: ServiceData
-var corsHandlerInitT = `{{ printf "%s creates a HTTP handler which returns a simple 200 response." .Endpoint.HandlerInit | comment }}
+var corsHandlerInitT = `{{ printf "%s creates a HTTP handler which returns a simple 204 response." .Endpoint.HandlerInit | comment }}
 func {{ .Endpoint.HandlerInit }}() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(204)
 	})
 }
 `
@@ -234,6 +234,8 @@ func {{ .OriginHandler }}(h http.Handler) http.Handler {
 				{{- if $policy.Headers }}
 			w.Header().Set("Access-Control-Allow-Headers", "{{ join $policy.Headers ", " }}")
 				{{- end }}
+			w.WriteHeader(204)
+			return
 		}
 		h.ServeHTTP(w, r)
 		return

--- a/cors/generate_test.go
+++ b/cors/generate_test.go
@@ -15,10 +15,10 @@ import (
 )
 
 func TestGenerate(t *testing.T) {
-	var corsHandler = `// NewCORSHandler creates a HTTP handler which returns a simple 200 response.
+	var corsHandler = `// NewCORSHandler creates a HTTP handler which returns a simple 204 response.
 func NewCORSHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(204)
 	})
 }
 `

--- a/cors/testdata/code.go
+++ b/cors/testdata/code.go
@@ -15,6 +15,8 @@ func HandleSimpleOriginOrigin(h http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return
@@ -41,6 +43,8 @@ func HandleRegexpOriginOrigin(h http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return
@@ -70,6 +74,8 @@ func HandleSimpleEnvVarOriginOrigin(h http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return
@@ -99,6 +105,8 @@ func HandleMultiOriginOrigin(h http.Handler) http.Handler {
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST")
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return
@@ -113,6 +121,8 @@ func HandleMultiOriginOrigin(h http.Handler) http.Handler {
 				// We are handling a preflight request
 				w.Header().Set("Access-Control-Allow-Methods", "GET, POST")
 				w.Header().Set("Access-Control-Allow-Headers", "X-Shared-Secret")
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return
@@ -138,6 +148,8 @@ func HandleOriginFileServerOrigin(h http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return
@@ -163,6 +175,8 @@ func HandleOriginMultiEndpointOrigin(h http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return
@@ -188,6 +202,8 @@ func HandleFirstServiceOrigin(h http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return
@@ -212,6 +228,8 @@ func HandleSecondServiceOrigin(h http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return
@@ -237,6 +255,8 @@ func HandleFilesOrigin(h http.Handler) http.Handler {
 			w.Header().Set("Vary", "Origin")
 			if acrm := r.Header.Get("Access-Control-Request-Method"); acrm != "" {
 				// We are handling a preflight request
+				w.WriteHeader(204)
+				return
 			}
 			h.ServeHTTP(w, r)
 			return


### PR DESCRIPTION
Previously it could return a 404, etc.
This had the effect of in the browser producting a network error because the preflight request failed.

These changes are passing the test suite but are not yet manually tested.