### PR TITLE
Allow use of deprecated functions

### DIFF
--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,3 +1,44 @@
+checks = [
+  # Enable all checks
+  "all",
+
+  # Disable SA1019
+  # Using a deprecated function, variable, constant or field.
+  # https://staticcheck.io/docs/checks#SA1019
+  "-SA1019",
+
+  # Disable ST1000
+  # Incorrect or missing package comment.
+  # https://staticcheck.io/docs/checks#ST1000
+  "-ST1000",
+
+  # Disable ST1003
+  # ST1003 - Poorly chosen identifier.
+  # https://staticcheck.io/docs/checks#ST1003
+  "-ST1003",
+
+  # Disable ST1016
+  # Use consistent method receiver names.
+  # https://staticcheck.io/docs/checks#ST1016
+  "-ST1016",
+
+  # Disable ST1020
+  # The documentation of an exported function should start with the
+  # function’s name.
+  # https://staticcheck.io/docs/checks#ST1020
+  "-ST1020",
+
+  # Disable ST1021
+  # The documentation of an exported type should start with type’s name.
+  # https://staticcheck.io/docs/checks#ST1021
+  "-ST1021",
+
+  # Disable ST1022
+  # The documentation of an exported variable or constant should start
+  # with variable’s name.
+  # https://staticcheck.io/docs/checks#ST1022
+  "-ST1022"
+]
 dot_import_whitelist = [
         "goa.design/goa/v3/dsl",
 ]


### PR DESCRIPTION
This is necessary until the default Goa main is updated and removes the use of Goa middlewares in favor of Clue.