### PR TITLE
types: support proto json_name override

### DIFF
--- a/types/proto.go
+++ b/types/proto.go
@@ -169,9 +169,20 @@ func generateProtoField(buf *strings.Builder, nat *expr.NamedAttributeExpr, fiel
 	buf.WriteString(codegen.Goify(nat.Name, false))
 	buf.WriteString(" = ")
 	buf.WriteString(fmt.Sprintf("%d", *fieldNum))
+	buf.WriteString(protoJSONOption(nat.Attribute))
 	buf.WriteString(";\n")
 
 	*fieldNum++
+}
+
+func protoJSONOption(att *expr.AttributeExpr) string {
+	if att == nil || att.Meta == nil {
+		return ""
+	}
+	if names := att.Meta["proto:tag:json"]; len(names) > 0 && names[0] != "" {
+		return fmt.Sprintf(" [json_name = %q]", names[0])
+	}
+	return ""
 }
 
 func protoType(dt expr.DataType) string {

--- a/types/proto_test.go
+++ b/types/proto_test.go
@@ -29,6 +29,7 @@ func TestProto(t *testing.T) {
 		{"alias", testdata.Alias},
 		{"array", testdata.Array},
 		{"recArray", testdata.ArrayArray},
+		{"protojson", testdata.ProtoJSON},
 	}
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {

--- a/types/testdata/dsls.go
+++ b/types/testdata/dsls.go
@@ -90,3 +90,11 @@ var ArrayArray = func() {
 		Required("array")
 	})
 }
+
+var ProtoJSON = func() {
+	var _ = Type("ProtoJSON", func() {
+		Attribute("value", String, func() {
+			Meta("proto:tag:json", "customValue")
+		})
+	})
+}

--- a/types/testdata/protojson.proto_
+++ b/types/testdata/protojson.proto_
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package types;
+
+option go_package = "example.com/test/types";
+
+message ProtoJSON {
+  string value = 1 [json_name = "customValue"];
+}
+


### PR DESCRIPTION
## Summary
- allow proto field definitions generated by the types plugin to honor `Meta("proto:tag:json", …)` by emitting the corresponding `json_name` option
- add regression coverage and a reproducible example to illustrate the new behavior

## Context
- aligns this plugin with goa/design change introduced in goadesign/goa#3857
