### PR TITLE
fix: update field naming to use snake_case in generated proto files

### DIFF
--- a/types/proto.go
+++ b/types/proto.go
@@ -166,7 +166,7 @@ func generateProtoField(buf *strings.Builder, nat *expr.NamedAttributeExpr, fiel
 	}
 
 	buf.WriteString(" ")
-	buf.WriteString(codegen.Goify(nat.Name, false))
+	buf.WriteString(codegen.SnakeCase(nat.Name))
 	buf.WriteString(" = ")
 	buf.WriteString(fmt.Sprintf("%d", *fieldNum))
 	buf.WriteString(protoJSONOption(nat.Attribute))

--- a/types/proto_test.go
+++ b/types/proto_test.go
@@ -146,3 +146,74 @@ func TestProtoTypeMapping(t *testing.T) {
 		})
 	}
 }
+
+func TestProtoFieldNaming(t *testing.T) {
+	tests := []struct {
+		name          string
+		dsl           func()
+		expectedField string
+	}{
+		{
+			"simple field",
+			func() {
+				Type("TestType", func() {
+					Attribute("field", String)
+				})
+			},
+			"string field = 1;",
+		},
+		{
+			"camelCase field",
+			func() {
+				Type("TestType", func() {
+					Attribute("myField", String)
+				})
+			},
+			"string my_field = 1;",
+		},
+		{
+			"PascalCase field",
+			func() {
+				Type("TestType", func() {
+					Attribute("MyField", String)
+				})
+			},
+			"string my_field = 1;",
+		},
+		{
+			"multiple words",
+			func() {
+				Type("TestType", func() {
+					Attribute("thisIsALongFieldName", String)
+				})
+			},
+			"string this_is_a_long_field_name = 1;",
+		},
+		{
+			"acronyms",
+			func() {
+				Type("TestType", func() {
+					Attribute("HTTPServer", String)
+				})
+			},
+			"string http_server = 1;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := codegen.RunDSL(t, tt.dsl)
+			fs, err := GenerateProto("test", []eval.Root{root}, nil)
+			require.NoError(t, err)
+			require.NotEmpty(t, fs)
+
+			var buf bytes.Buffer
+			for _, s := range fs[0].SectionTemplates {
+				require.NoError(t, s.Write(&buf))
+			}
+
+			got := buf.String()
+			assert.Contains(t, got, tt.expectedField, "Proto should use snake_case for field names")
+		})
+	}
+}


### PR DESCRIPTION
## Fix: Use snake_case for proto field names

### Problem
The types plugin was generating proto fields in camelCase (`firstName`, `emailAddress`) instead of the standard snake_case convention (`first_name`, `email_address`).

### Solution
Changed `types/proto.go` line 169 to use `codegen.SnakeCase()` instead of `codegen.Goify()`.

### Testing
- Added `TestProtoFieldNaming` with tests for camelCase, acronyms, and multiple word fields
- All existing tests pass
- Verified with reproduction case showing correct conversions:
  - `firstName` => `first_name`
  - `HTTPSEnabled` => `https_enabled`
  - `profilePictureURL` => `profile_picture_url`