### PR TITLE
Fix incorrect import paths in model and cors DSL godoc examples

### DIFF
--- a/cors/dsl/cors.go
+++ b/cors/dsl/cors.go
@@ -27,7 +27,7 @@ import (
 //
 // Example:
 //
-//	import cors "goa.design/plugins/v3/cors"
+//	import cors "goa.design/plugins/v3/cors/dsl"
 //
 //	var _ = API("calc", func() {
 //	    cors.Origin("http://swagger.goa.design", func() { // Define CORS policy, may be prefixed with "*" wildcard

--- a/model/dsl/model.go
+++ b/model/dsl/model.go
@@ -16,7 +16,7 @@ import (
 //
 // Example:
 //
-//	import . "goa.design/plugins/v3/model"
+//	import . "goa.design/plugins/v3/model/dsl"
 //
 //	var _ = API("calc", func() {
 //	   Model("goa.design/model/examples/basic/model", "calc")
@@ -34,7 +34,7 @@ func Model(path, systemName string) {
 //
 // Example:
 //
-//	import . "goa.design/plugins/v3/model"
+//	import . "goa.design/plugins/v3/model/dsl"
 //
 //	var _ = API("calc", func() {
 //	   Model("goa.design/model/examples/basic/model", "calc")
@@ -52,7 +52,7 @@ func ModelContainerFormat(format string) {
 //
 // Example:
 //
-//	import . "goa.design/plugins/v3/model"
+//	import . "goa.design/plugins/v3/model/dsl"
 //
 //	var _ = API("calc", func() {
 //	   Model("goa.design/model/examples/basic/model", "calc")
@@ -70,7 +70,7 @@ func ModelExcludedTags(tags ...string) {
 //
 // Example:
 //
-//	import . "goa.design/plugins/v3/model"
+//	import . "goa.design/plugins/v3/model/dsl"
 //
 //	var _ = API("calc", func() {
 //	   Model("goa.design/model/examples/basic/model", "calc")
@@ -86,7 +86,7 @@ func ModelComplete() {
 //
 // Example:
 //
-//	import . "goa.design/plugins/v3/model"
+//	import . "goa.design/plugins/v3/model/dsl"
 //
 //	var _ = API("calc", func() {
 //		Service("adder", func() {
@@ -108,7 +108,7 @@ func ModelContainer(name string) {
 //
 // Example:
 //
-//	import . "goa.design/plugins/v3/model"
+//	import . "goa.design/plugins/v3/model/dsl"
 //
 //	var _ = API("calc", func() {
 //		Service("adder", func() {


### PR DESCRIPTION
The godoc examples in model/dsl and cors/dsl referenced the parent packages (goa.design/plugins/v3/model and goa.design/plugins/v3/cors) instead of the correct dsl subpackages. Users following these examples would import packages that don't export the documented DSL functions.