### PR TITLE
Fix apipkg lookup in GenerateExample of testing plugin

### DIFF
--- a/testing/generate.go
+++ b/testing/generate.go
@@ -1,8 +1,6 @@
 package testing
 
 import (
-	"strings"
-
 	"goa.design/goa/v3/codegen"
 	"goa.design/goa/v3/codegen/service"
 	"goa.design/goa/v3/eval"
@@ -52,9 +50,25 @@ func GenerateExample(genpkg string, roots []eval.Root, files []*codegen.File) ([
 			continue
 		}
 		for _, svc := range r.Services {
-			// Derive example implementation package name deterministically like Goa example generator
-			snake := codegen.SnakeCase(svc.Name)
-			apipkg := strings.ReplaceAll(snake, "_", "") + "api"
+			// Get example implementation package name from actual file header
+			var apipkg string
+			for _, f := range files {
+				for _, section := range f.Section("source-header") {
+					header, ok := section.Data.(map[string]any)
+					if !ok {
+						continue
+					}
+					p, ok := header["Pkg"].(string)
+					if !ok {
+						continue
+					}
+					apipkg = p
+					break
+				}
+				if apipkg != "" {
+					break
+				}
+			}
 			if f := testcodegen.GenerateSuiteTopLevel(genpkg, apipkg, r, svc); f != nil {
 				files = append(files, f)
 			}

--- a/testing/generate.go
+++ b/testing/generate.go
@@ -1,6 +1,8 @@
 package testing
 
 import (
+	"strings"
+
 	"goa.design/goa/v3/codegen"
 	"goa.design/goa/v3/codegen/service"
 	"goa.design/goa/v3/eval"
@@ -49,26 +51,17 @@ func GenerateExample(genpkg string, roots []eval.Root, files []*codegen.File) ([
 		if !ok {
 			continue
 		}
+		services := service.NewServicesData(r)
+		scope := codegen.NewNameScope()
 		for _, svc := range r.Services {
-			// Get example implementation package name from actual file header
-			var apipkg string
-			for _, f := range files {
-				for _, section := range f.Section("source-header") {
-					header, ok := section.Data.(map[string]any)
-					if !ok {
-						continue
-					}
-					p, ok := header["Pkg"].(string)
-					if !ok {
-						continue
-					}
-					apipkg = p
-					break
-				}
-				if apipkg != "" {
-					break
-				}
+			s := services.Get(svc.Name)
+			if s == nil {
+				continue
 			}
+			scope.Unique(s.PkgName)
+		}
+		apipkg := scope.Unique(strings.ToLower(codegen.Goify(r.API.Name, false)), "api")
+		for _, svc := range r.Services {
 			if f := testcodegen.GenerateSuiteTopLevel(genpkg, apipkg, r, svc); f != nil {
 				files = append(files, f)
 			}


### PR DESCRIPTION
This pull request updates the logic in the `testing/generate.go` file to improve how the example implementation package name is determined when generating test suites. Instead of deriving the package name using string manipulation, the code now extracts it directly from the file header metadata, making the process more robust and accurate.

**Improvements to package name determination:**

* Changed the method for determining the example implementation package name in `GenerateExample` to extract it from the file header's `Pkg` field, rather than constructing it from the service name using string manipulation.

**Code cleanup:**

* Removed the unnecessary import of the `strings` package from `testing/generate.go`.