### PR TITLE
Fix godoc in suite_test template of testing plugin

### DIFF
--- a/testing/codegen/templates/suite_test.go.tpl
+++ b/testing/codegen/templates/suite_test.go.tpl
@@ -1,4 +1,4 @@
-{{ printf "Run%sHarness exercises the generated harness against your service implementation." .Service.Name | comment }}
+{{ printf "Run%sHarness exercises the generated harness against your service implementation." .Service.StructName | comment }}
 {{ printf "Call this helper from your test, passing your service implementation." | comment }}
 func Run{{ .Service.StructName }}Harness(t *testing.T, svc {{ .Service.PkgName }}.Service) {
 	t.Helper()

--- a/testing/examples/calculator/calculator_suite_test.go
+++ b/testing/examples/calculator/calculator_suite_test.go
@@ -10,7 +10,7 @@ import (
 	calculatortest "goa.design/plugins/v3/testing/examples/calculator/gen/calculator/calculatortest"
 )
 
-// RuncalculatorHarness exercises the generated harness against your service
+// RunCalculatorHarness exercises the generated harness against your service
 // implementation.
 // Call this helper from your test, passing your service implementation.
 func RunCalculatorHarness(t *testing.T, svc calculator.Service) {

--- a/testing/examples/httpgrpc/test_http_grpc_suite_test.go
+++ b/testing/examples/httpgrpc/test_http_grpc_suite_test.go
@@ -10,8 +10,8 @@ import (
 	testHTTPGrpctest "goa.design/plugins/v3/testing/examples/httpgrpc/gen/test_http_grpc/test_http_grpctest"
 )
 
-// Runtest-http-grpcHarness exercises the generated harness against your
-// service implementation.
+// RunTestHTTPGrpcHarness exercises the generated harness against your service
+// implementation.
 // Call this helper from your test, passing your service implementation.
 func RunTestHTTPGrpcHarness(t *testing.T, svc testhttpgrpc.Service) {
 	t.Helper()

--- a/testing/examples/jsonrpc/test_jsonrpc_suite_test.go
+++ b/testing/examples/jsonrpc/test_jsonrpc_suite_test.go
@@ -9,7 +9,7 @@ import (
 	testJsonrpctest "goa.design/plugins/v3/testing/examples/jsonrpc/gen/test_jsonrpc/test_jsonrpctest"
 )
 
-// Runtest-jsonrpcHarness exercises the generated harness against your service
+// RunTestJsonrpcHarness exercises the generated harness against your service
 // implementation.
 // Call this helper from your test, passing your service implementation.
 func RunTestJsonrpcHarness(t *testing.T, svc testjsonrpc.Service) {


### PR DESCRIPTION
This pull request updates the naming conventions for generated test harness helpers and their documentation comments to use proper Go-style capitalization and struct names, improving consistency and readability across the codebase.

**Test harness naming and documentation consistency:**

* Updated the documentation comment in `suite_test.go.tpl` to use `.Service.StructName` instead of `.Service.Name`, ensuring the generated comment references the correct struct name.
* Corrected the function name and comment in `calculator_suite_test.go` from `RuncalculatorHarness` to `RunCalculatorHarness`, matching Go naming conventions.
* Corrected the function name and comment in `test_http_grpc_suite_test.go` from `Runtest-http-grpcHarness` to `RunTestHTTPGrpcHarness`, using proper capitalization and removing dashes.
* Corrected the function name and comment in `test_jsonrpc_suite_test.go` from `Runtest-jsonrpcHarness` to `RunTestJsonrpcHarness`, using proper capitalization and removing dashes.